### PR TITLE
fixed double callback call on some errors

### DIFF
--- a/src/utils/apiUtils/chartData.js
+++ b/src/utils/apiUtils/chartData.js
@@ -294,8 +294,7 @@ export const requestQuote = (symbol, callback) => {
     stockQuote => {
       modules.forEach(module => {
         if (!stockQuote[module]) {
-          callback(`Module '${module}' was not found.`);
-          return;
+          throw new Error(`Module '${module}' was not found.`);
         }
       });
       callback(null, createStock(stockQuote));
@@ -315,8 +314,7 @@ export const requestMaxStockData = (symbol, callback) => {
   }).then(
     dailyData => {
       if (!dailyData[0]) {
-        callback('Historical data was not found.');
-        return;
+        throw new Error('Historical data was not found.');
       }
       callback(null, getDatesAndPrices(dailyData));
     }


### PR DESCRIPTION
Fixes #100.

I request you do your best to make the "Unhandled rejection Error: Callback was already called." come up again, because I had a hard time reliably getting it to happen but now can't get it to happen at all with this fix. 

Fix is based on this link: https://github.com/caolan/async/issues/1150

Edit: only stopped the message in some cases, still don't know what is causing it.
~~This fix also seems to have stopped the~~ ```root.Api.main context.dispatcher.stores.CrumbStore.crumb structure no longer exists, please open an issue.``` ~~messages~~.

