### PR TITLE
added max length to search input based on longest expected ticker symbol

### DIFF
--- a/src/client/components/search/Search.jsx
+++ b/src/client/components/search/Search.jsx
@@ -51,6 +51,7 @@ const Search = ({
         required
         onFocus={ focusEndOfInput }
         spellCheck="false"
+        maxLength="15"
       />
       <FontAwesome
         className='searchButton'


### PR DESCRIPTION
Fixes #98.

https://www.quora.com/What-is-the-longest-ticker-symbol-on-the-NYSE implied the limit could be 15 characters for other stock exchanges.
Other links seem to say the longest ticker on the NYSE is 5 symbols, but I think a higher number is a safer bet. NASDAQ can go to at least 6, and other exchanges may be much longer.

Comment if you have input.