### PR TITLE
Fix time period button crash

### DIFF
--- a/src/client/components/chart/Chart.jsx
+++ b/src/client/components/chart/Chart.jsx
@@ -45,11 +45,12 @@ const Chart = ({
         className='chart' >
         <CartesianGrid strokeDashArray='3 3' />
         <XAxis dataKey={ getXAxisDataKey() }
-          tickFormatter= { getXAxisTickFormatter() }
+          tickFormatter={ getXAxisTickFormatter() }
           minTickGap={ getXAxisMinTickGap() } />
         <YAxis dataKey={ CHART_DATA_KEY_Y_AXIS } domain={ ['auto', 'auto'] }
           tickFormatter={ addCommas } />
-        <Tooltip labelFormatter = { getTooltipLabelFormatter() }
+        <Tooltip
+          labelFormatter={ getTooltipLabelFormatter() }
           formatter={ price => formatAsPrice(price) }
           separator=': ' />
         <Line type='monotone' dataKey={ CHART_DATA_KEY_Y_AXIS } dot={ false }

--- a/src/constants/utilityConstants.js
+++ b/src/constants/utilityConstants.js
@@ -1,9 +1,8 @@
 import {
+  formatDateIfValid,
   getStockDataForPreviousMonths,
   getStockDataForPreviousYears
 } from '../utils/dateUtils';
-
-import dateFormat from 'dateformat';
 
 export const CHART_DATA_KEY_Y_AXIS = 'price';
 export const CHART_LINE_COLOR = 'red';
@@ -15,8 +14,10 @@ export const CHART_META_DATA = [
     xAxisDataKey: 'dateAndTime',
     xAxisMinTickGap: 100,
     getStockDataForTimePeriod: oneDayStockData => oneDayStockData,
-    getTooltipLabelFormatter: dateAndTime => 'time: ' + dateAndTime,
-    getXAxisTickFormatter: dateAndTime => dateAndTime
+    getTooltipLabelFormatter: dateAndTime =>
+      'time: ' + dateAndTime,
+    getXAxisTickFormatter: dateAndTime =>
+      dateAndTime
   },
   {
     label: '5 day',
@@ -25,9 +26,9 @@ export const CHART_META_DATA = [
     xAxisMinTickGap: 110,
     getStockDataForTimePeriod: fiveDayStockData => fiveDayStockData,
     getTooltipLabelFormatter: dateAndTime =>
-      dateFormat(dateAndTime, 'mmm d, h:MM TT'),
+      formatDateIfValid(dateAndTime, 'mmm d, h:MM TT'),
     getXAxisTickFormatter: dateAndTime =>
-      dateFormat(dateAndTime, 'mmm d, h:MM TT')
+      formatDateIfValid(dateAndTime, 'mmm d, h:MM TT')
   },
   {
     label: '1 month',
@@ -36,8 +37,10 @@ export const CHART_META_DATA = [
     xAxisMinTickGap: 60,
     getStockDataForTimePeriod: maxStockData =>
       getStockDataForPreviousMonths(maxStockData, 1),
-    getTooltipLabelFormatter: date => dateFormat(date, 'mmm d, yyyy'),
-    getXAxisTickFormatter: date => dateFormat(date, 'mmm d')
+    getTooltipLabelFormatter: date =>
+      formatDateIfValid(date, 'mmm d, yyyy'),
+    getXAxisTickFormatter: date =>
+      formatDateIfValid(date, 'mmm d')
   },
   {
     label: '3 month',
@@ -46,8 +49,10 @@ export const CHART_META_DATA = [
     xAxisMinTickGap: 100,
     getStockDataForTimePeriod: maxStockData =>
       getStockDataForPreviousMonths(maxStockData, 3),
-    getTooltipLabelFormatter: date => dateFormat(date, 'mmm d, yyyy'),
-    getXAxisTickFormatter: date => dateFormat(date, 'mmm d')
+    getTooltipLabelFormatter: date =>
+      formatDateIfValid(date, 'mmm d, yyyy'),
+    getXAxisTickFormatter: date =>
+      formatDateIfValid(date, 'mmm d')
   },
   {
     label: '1 year',
@@ -56,8 +61,10 @@ export const CHART_META_DATA = [
     xAxisMinTickGap: 30,
     getStockDataForTimePeriod: maxStockData =>
       getStockDataForPreviousYears(maxStockData, 1),
-    getTooltipLabelFormatter: date => dateFormat(date, 'mmm d, yyyy'),
-    getXAxisTickFormatter: date => dateFormat(date, 'mmm d')
+    getTooltipLabelFormatter: date =>
+      formatDateIfValid(date, 'mmm d, yyyy'),
+    getXAxisTickFormatter: date =>
+      formatDateIfValid(date, 'mmm d')
   },
   {
     label: '5 year',
@@ -66,8 +73,10 @@ export const CHART_META_DATA = [
     xAxisMinTickGap: 120,
     getStockDataForTimePeriod: maxStockData =>
       getStockDataForPreviousYears(maxStockData, 5),
-    getTooltipLabelFormatter: date => dateFormat(date, 'mmm d, yyyy'),
-    getXAxisTickFormatter: date => dateFormat(date, 'mmm yyyy')
+    getTooltipLabelFormatter: date =>
+      formatDateIfValid(date, 'mmm d, yyyy'),
+    getXAxisTickFormatter: date =>
+      formatDateIfValid(date, 'mmm yyyy')
   },
   {
     label: 'max',
@@ -75,8 +84,10 @@ export const CHART_META_DATA = [
     xAxisDataKey: 'date',
     xAxisMinTickGap: 130,
     getStockDataForTimePeriod: maxStockData => maxStockData,
-    getTooltipLabelFormatter: date => dateFormat(date, 'mmm d, yyyy'),
-    getXAxisTickFormatter: date => dateFormat(date, 'mmm yyyy')
+    getTooltipLabelFormatter: date =>
+      formatDateIfValid(date, 'mmm d, yyyy'),
+    getXAxisTickFormatter: date =>
+      formatDateIfValid(date, 'mmm yyyy')
   }
 ];
 

--- a/src/constants/utilityConstants.js
+++ b/src/constants/utilityConstants.js
@@ -1,5 +1,5 @@
 import {
-  formatDateIfValid,
+  tryFormatDate,
   getStockDataForPreviousMonths,
   getStockDataForPreviousYears
 } from '../utils/dateUtils';
@@ -26,9 +26,9 @@ export const CHART_META_DATA = [
     xAxisMinTickGap: 110,
     getStockDataForTimePeriod: fiveDayStockData => fiveDayStockData,
     getTooltipLabelFormatter: dateAndTime =>
-      formatDateIfValid(dateAndTime, 'mmm d, h:MM TT'),
+      tryFormatDate(dateAndTime, 'mmm d, h:MM TT'),
     getXAxisTickFormatter: dateAndTime =>
-      formatDateIfValid(dateAndTime, 'mmm d, h:MM TT')
+      tryFormatDate(dateAndTime, 'mmm d, h:MM TT')
   },
   {
     label: '1 month',
@@ -38,9 +38,9 @@ export const CHART_META_DATA = [
     getStockDataForTimePeriod: maxStockData =>
       getStockDataForPreviousMonths(maxStockData, 1),
     getTooltipLabelFormatter: date =>
-      formatDateIfValid(date, 'mmm d, yyyy'),
+      tryFormatDate(date, 'mmm d, yyyy'),
     getXAxisTickFormatter: date =>
-      formatDateIfValid(date, 'mmm d')
+      tryFormatDate(date, 'mmm d')
   },
   {
     label: '3 month',
@@ -50,9 +50,9 @@ export const CHART_META_DATA = [
     getStockDataForTimePeriod: maxStockData =>
       getStockDataForPreviousMonths(maxStockData, 3),
     getTooltipLabelFormatter: date =>
-      formatDateIfValid(date, 'mmm d, yyyy'),
+      tryFormatDate(date, 'mmm d, yyyy'),
     getXAxisTickFormatter: date =>
-      formatDateIfValid(date, 'mmm d')
+      tryFormatDate(date, 'mmm d')
   },
   {
     label: '1 year',
@@ -62,9 +62,9 @@ export const CHART_META_DATA = [
     getStockDataForTimePeriod: maxStockData =>
       getStockDataForPreviousYears(maxStockData, 1),
     getTooltipLabelFormatter: date =>
-      formatDateIfValid(date, 'mmm d, yyyy'),
+      tryFormatDate(date, 'mmm d, yyyy'),
     getXAxisTickFormatter: date =>
-      formatDateIfValid(date, 'mmm d')
+      tryFormatDate(date, 'mmm d')
   },
   {
     label: '5 year',
@@ -74,9 +74,9 @@ export const CHART_META_DATA = [
     getStockDataForTimePeriod: maxStockData =>
       getStockDataForPreviousYears(maxStockData, 5),
     getTooltipLabelFormatter: date =>
-      formatDateIfValid(date, 'mmm d, yyyy'),
+      tryFormatDate(date, 'mmm d, yyyy'),
     getXAxisTickFormatter: date =>
-      formatDateIfValid(date, 'mmm yyyy')
+      tryFormatDate(date, 'mmm yyyy')
   },
   {
     label: 'max',
@@ -85,9 +85,9 @@ export const CHART_META_DATA = [
     xAxisMinTickGap: 130,
     getStockDataForTimePeriod: maxStockData => maxStockData,
     getTooltipLabelFormatter: date =>
-      formatDateIfValid(date, 'mmm d, yyyy'),
+      tryFormatDate(date, 'mmm d, yyyy'),
     getXAxisTickFormatter: date =>
-      formatDateIfValid(date, 'mmm yyyy')
+      tryFormatDate(date, 'mmm yyyy')
   }
 ];
 

--- a/src/utils/dateUtils/dateFormatting.js
+++ b/src/utils/dateUtils/dateFormatting.js
@@ -20,7 +20,7 @@ export const formatDateForMaxStockData = date => {
   return `${year}-${month}-${day}`;
 };
 
-export function formatDateIfValid(date, format) {
+export function tryFormatDate(date, format) {
   try {
     return dateFormat(date, format);
   } catch (error) {

--- a/src/utils/dateUtils/dateFormatting.js
+++ b/src/utils/dateUtils/dateFormatting.js
@@ -1,3 +1,5 @@
+import dateFormat from 'dateformat';
+
 import { padSingleDigitWithZero } from '../formatting/numberFormatting';
 
 // Reinventing the wheel here, but it was good unit testing
@@ -17,3 +19,12 @@ export const formatDateForMaxStockData = date => {
   const year = date.getFullYear();
   return `${year}-${month}-${day}`;
 };
+
+export function formatDateIfValid(date, format) {
+  try {
+    return dateFormat(date, format);
+  } catch (error) {
+    console.error(error);
+  }
+  return date;
+}

--- a/src/utils/dateUtils/index.js
+++ b/src/utils/dateUtils/index.js
@@ -6,8 +6,7 @@ export {
 
 export {
   formatDateForMaxStockData,
-  formatDateIfValid,
-  isValidDate
+  formatDateIfValid
 } from './dateFormatting';
 
 export {

--- a/src/utils/dateUtils/index.js
+++ b/src/utils/dateUtils/index.js
@@ -6,7 +6,7 @@ export {
 
 export {
   formatDateForMaxStockData,
-  formatDateIfValid
+  tryFormatDate
 } from './dateFormatting';
 
 export {

--- a/src/utils/dateUtils/index.js
+++ b/src/utils/dateUtils/index.js
@@ -5,7 +5,9 @@ export {
 } from './dateCalculations';
 
 export {
-  formatDateForMaxStockData
+  formatDateForMaxStockData,
+  formatDateIfValid,
+  isValidDate
 } from './dateFormatting';
 
 export {


### PR DESCRIPTION
Fixes #106 and #51.

Errors are still printed to the console (from the catch block in the new method) but the app no longer crashes.