### PR TITLE
added min-height to nav to prevent vertical squish in firefox

### DIFF
--- a/src/client/components/navBar/navBar.css
+++ b/src/client/components/navBar/navBar.css
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center;
   color: white;
+  min-height: 50px;
   height: 50px;
   width: 100%;
 }


### PR DESCRIPTION
Fix #111

Before:
<img width="1440" alt="screen shot 2018-08-27 at 5 09 23 pm" src="https://user-images.githubusercontent.com/9269522/44693364-3cc2b680-aa1c-11e8-8ebb-d3213832981e.png">

After:
<img width="1440" alt="screen shot 2018-08-27 at 5 10 13 pm" src="https://user-images.githubusercontent.com/9269522/44693369-41876a80-aa1c-11e8-8bc4-d4e516b36fb6.png">
