### PR TITLE
Definition component test improvement

### DIFF
--- a/src/client/components/definition/Definition.jsx
+++ b/src/client/components/definition/Definition.jsx
@@ -7,8 +7,14 @@ const Definition = ({
   definition
 }) => (
   <div className='definition'>
-    <h2>{ definition.title }</h2>
-    <p>{ definition.definition }</p>
+    { definition.title
+      ? <h2>{ definition.title }</h2>
+      : null
+    }
+    { definition.definition
+      ? <p>{ definition.definition }</p>
+      : null
+    }
     { definition.equations
       ? definition.equations.map(equation => (
         <p key={equation}>$${equation}$$</p>

--- a/src/client/components/definition/Definition.test.jsx
+++ b/src/client/components/definition/Definition.test.jsx
@@ -31,12 +31,21 @@ describe('<Definition />', () => {
     expect(title).to.equal(mockTitle);
     expect(definition).to.equal(mockDefinition);
   });
-  it('displays 2 equations properly', () => {
+  it('displays 2 equations', () => {
     const wrapper = shallow(
       <Definition definition={{
         equations: mockEquations
       }} />
     );
     expect(wrapper.find('p')).to.have.lengthOf(2);
+  });
+  it('displays correct text in 2 equations', () => {
+    const wrapper = shallow(
+      <Definition definition={{
+        equations: mockEquations
+      }} />
+    );
+    expect(wrapper.find('p').at(0).text()).to.equal('$$equation1$$');
+    expect(wrapper.find('p').at(1).text()).to.equal('$$equation2$$');
   });
 });

--- a/src/client/components/definition/Definition.test.jsx
+++ b/src/client/components/definition/Definition.test.jsx
@@ -18,6 +18,13 @@ describe('<Definition />', () => {
     );
     expect(wrapper).to.have.className('definition');
   });
+  it('renders no paragraphs or h2\'s if given an empty object', () => {
+    const wrapper = shallow(
+      <Definition definition={{}} />
+    );
+    expect(wrapper.find('h2')).to.have.length(0);
+    expect(wrapper.find('p')).to.have.length(0);
+  });
   it('displays the provided title', () => {
     const wrapper = shallow(
       <Definition definition={{

--- a/src/client/components/definition/Definition.test.jsx
+++ b/src/client/components/definition/Definition.test.jsx
@@ -6,6 +6,7 @@ import Definition from './Definition';
 
 const mockTitle = 'P/E';
 const mockDefinition = 'P/E is price-to-earnings';
+const mockEquations = ['equation1', 'equation2'];
 
 describe('<Definition />', () => {
   it('has expected className for styling', () => {
@@ -30,5 +31,12 @@ describe('<Definition />', () => {
     expect(title).to.equal(mockTitle);
     expect(definition).to.equal(mockDefinition);
   });
-  // TODO: test equation rendering
+  it('displays 2 equations properly', () => {
+    const wrapper = shallow(
+      <Definition definition={{
+        equations: mockEquations
+      }} />
+    );
+    expect(wrapper.find('p')).to.have.lengthOf(2);
+  });
 });

--- a/src/client/components/definition/Definition.test.jsx
+++ b/src/client/components/definition/Definition.test.jsx
@@ -18,26 +18,24 @@ describe('<Definition />', () => {
     );
     expect(wrapper).to.have.className('definition');
   });
-  it('displays the provided title and definition', () => {
+  it('displays the provided title', () => {
     const wrapper = shallow(
       <Definition definition={{
-        title: mockTitle,
-        definition: mockDefinition
+        title: mockTitle
       }} />
     );
     const title = wrapper.find('h2').first().text();
-    const definition = wrapper.find('p').first().text();
 
     expect(title).to.equal(mockTitle);
-    expect(definition).to.equal(mockDefinition);
   });
-  it('displays 2 equations', () => {
+  it('displays the provided definition', () => {
     const wrapper = shallow(
       <Definition definition={{
-        equations: mockEquations
+        definition: mockDefinition
       }} />
     );
-    expect(wrapper.find('p')).to.have.lengthOf(2);
+    const definition = wrapper.find('p').first().text();
+    expect(definition).to.equal(mockDefinition);
   });
   it('displays correct text in 2 equations', () => {
     const wrapper = shallow(


### PR DESCRIPTION
Should I test what happens if `definition.title = undefined`  or `definition.definition = undefined`?

Is it okay that we test that both title and definition are displayed in the same test? Should they be in separate tests? (you wrote that one)

What about a test where both definition and equations are rendered? Would it be sufficient to render 1 definition and 2 equations, then write `expect(wrapper.find('p)).to.have.lengthOf(3)`? This seems like less of a unit test, but using this lengthOf comparison seems like a hack in general.

Suggestions for what more should be tested in this component? 
Let me know your thoughts