### PR TITLE
Test data item

### DIFF
--- a/src/client/components/dataItem/DataItem.jsx
+++ b/src/client/components/dataItem/DataItem.jsx
@@ -15,17 +15,15 @@ export const DataItem = ({
       <span>
         { label }
       </span>
-      { value
-        ? <span className='value'>
-          { value }
-        </span>
-        : null }
+      <span className='value'>
+        { value }
+      </span>
     </div>
   );
 };
 DataItem.propTypes = {
   label: PropTypes.string.isRequired,
   showBottomBorder: PropTypes.bool,
-  value: PropTypes.string
+  value: PropTypes.string.isRequired
 };
 export default DataItem;

--- a/src/client/components/dataItem/DataItem.test.jsx
+++ b/src/client/components/dataItem/DataItem.test.jsx
@@ -5,8 +5,6 @@ import { expect } from 'chai';
 import { DataItem } from './DataItem';
 
 describe('<DataItem />', () => {
-  let wrapper;
-
   const baseProps = {
     label: 'High',
     showBottomBorder: true,
@@ -14,7 +12,7 @@ describe('<DataItem />', () => {
   };
 
   it('has the correct className with showBottomBorder = true', () => {
-    wrapper = shallow(<DataItem { ...baseProps } />);
+    const wrapper = shallow(<DataItem { ...baseProps } />);
     expect(wrapper).to.have.className('dataItem dataItemBorder');
   });
   it('has the correct className with showBottomBorder = false', () => {
@@ -22,19 +20,19 @@ describe('<DataItem />', () => {
       ...baseProps,
       showBottomBorder: false
     };
-    wrapper = shallow(<DataItem { ...bottomBorderFalseProps } />);
+    const wrapper = shallow(<DataItem { ...bottomBorderFalseProps } />);
     expect(wrapper).to.have.className('dataItem');
   });
-  it('has the correct className for second (value) span', () => {
-    wrapper = shallow(<DataItem { ...baseProps } />);
+  it('has the correct className for the span that holds the value', () => {
+    const wrapper = shallow(<DataItem { ...baseProps } />);
     expect(wrapper.find('span').at(1)).to.have.className('value');
   });
-  it('renders first (label) span with a child of "High"', () => {
-    wrapper = shallow(<DataItem { ...baseProps } />);
+  it('renders the correct label', () => {
+    const wrapper = shallow(<DataItem { ...baseProps } />);
     expect(wrapper.find('span').at(0).text()).to.equal('High');
   });
-  it('renders second (value) span with a child of "113.36"', () => {
-    wrapper = shallow(<DataItem { ...baseProps } />);
+  it('renders the correct value', () => {
+    const wrapper = shallow(<DataItem { ...baseProps } />);
     expect(wrapper.find('span').at(1).text()).to.equal('113.36');
   });
 });

--- a/src/client/components/dataItem/DataItem.test.jsx
+++ b/src/client/components/dataItem/DataItem.test.jsx
@@ -25,4 +25,16 @@ describe('<DataItem />', () => {
     wrapper = shallow(<DataItem { ...bottomBorderFalseProps } />);
     expect(wrapper).to.have.className('dataItem');
   });
+  it('has the correct className for second (value) span', () => {
+    wrapper = shallow(<DataItem { ...baseProps } />);
+    expect(wrapper.find('span').at(1)).to.have.className('value');
+  });
+  it('renders first (label) span with a child of "High"', () => {
+    wrapper = shallow(<DataItem { ...baseProps } />);
+    expect(wrapper.find('span').at(0).text()).to.equal('High');
+  });
+  it('renders second (value) span with a child of "113.36"', () => {
+    wrapper = shallow(<DataItem { ...baseProps } />);
+    expect(wrapper.find('span').at(1).text()).to.equal('113.36');
+  });
 });

--- a/src/client/components/dataItem/DataItem.test.jsx
+++ b/src/client/components/dataItem/DataItem.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import { DataItem } from './DataItem';
+
+describe('<DataItem />', () => {
+  let wrapper;
+
+  const baseProps = {
+    label: 'High',
+    showBottomBorder: true,
+    value: '113.36'
+  };
+
+  it('has the correct className with showBottomBorder = true', () => {
+    wrapper = shallow(<DataItem { ...baseProps } />);
+    expect(wrapper).to.have.className('dataItem dataItemBorder');
+  });
+  it('has the correct className with showBottomBorder = false', () => {
+    const bottomBorderFalseProps = {
+      ...baseProps,
+      showBottomBorder: false
+    };
+    wrapper = shallow(<DataItem { ...bottomBorderFalseProps } />);
+    expect(wrapper).to.have.className('dataItem');
+  });
+});


### PR DESCRIPTION
Took out ternary for rendering value. Value should be required, I made it not required because it was breaking Column tests. Column tests are now using a dumb component instead of the real DataItem component (that was really dumb of me) so the ternary isn't required.