### PR TITLE
integration tests for root reducer

### DIFF
--- a/src/client/reducers/index.test.js
+++ b/src/client/reducers/index.test.js
@@ -15,9 +15,13 @@ import {
 
 /* eslint-disable no-undefined */
 
-let store = createStore(reducer);
-
 describe('Reducers are connected to the store as expected', () => {
+  let store;
+
+  beforeAll(() => {
+    store = createStore(reducer);
+  });
+
   test('initial state matches each reducer with empty action', () => {
     expect(store.getState().chartTimePeriodIndex)
       .toEqual(chartTimePeriodIndex(4, {}));


### PR DESCRIPTION
https://github.com/reduxjs/redux/issues/1412

had a hard time decoupling tests from child reducer implementation details. 

In his example, he says action: { type: INCREMENT } but this doesn't actually change anything so how does he know the reducers received the action?.

Anyways my other idea was to simply export the object we are passing to combineReducers and make sure it includes the reducers we are expecting, and leave it at that. This (integration) test may be overboard.